### PR TITLE
tokenファイルの読み込みのエラーハンドリング

### DIFF
--- a/denops/traqvim/api.ts
+++ b/denops/traqvim/api.ts
@@ -21,10 +21,15 @@ export class TraqApi {
     // tokenFilePathが存在しない場合は作成
     Deno.mkdir(path.dirname(this.tokenFilePath), { recursive: true });
     // 既にtokenが記録されているならそれを読み込む
-    if (Deno.statSync(this.tokenFilePath).isFile) {
-      console.log("token file exists");
-      this.loadToken();
-    }
+	try {
+	  const fileInfo = Deno.statSync(this.tokenFilePath);
+	  if (fileInfo.isFile) {
+		this.loadToken();
+	  }
+	} catch (e) {
+	  console.log(e);
+	  console.log("please Done :TraqSetup");
+	}
   }
   setToken(token: Tokens) {
     this.token = token;

--- a/denops/traqvim/api.ts
+++ b/denops/traqvim/api.ts
@@ -21,15 +21,15 @@ export class TraqApi {
     // tokenFilePathが存在しない場合は作成
     Deno.mkdir(path.dirname(this.tokenFilePath), { recursive: true });
     // 既にtokenが記録されているならそれを読み込む
-	try {
-	  const fileInfo = Deno.statSync(this.tokenFilePath);
-	  if (fileInfo.isFile) {
-		this.loadToken();
-	  }
-	} catch (e) {
-	  console.log(e);
-	  console.log("please Done :TraqSetup");
-	}
+    try {
+      const fileInfo = Deno.statSync(this.tokenFilePath);
+      if (fileInfo.isFile) {
+        this.loadToken();
+      }
+    } catch (e) {
+      console.log(e);
+      console.log("please Done :TraqSetup");
+    }
   }
   setToken(token: Tokens) {
     this.token = token;


### PR DESCRIPTION
token.jsonがない状態で開くとエラーが出てプラグインの読み込みすら起きないので、ひとまずエラーが起きると`:TraqSetup`してね～と表示するようにして、プラグインの読み込み自体は行われるようにした

後でtokenが無い状態で色々しようとしたときのエラーをちゃんとハンドリングしておかないとなぁ