### PR TITLE
dduのソースからもapiのtokenFileのパス設定を行うよう変更

### DIFF
--- a/denops/@ddc-sources/stamp.ts
+++ b/denops/@ddc-sources/stamp.ts
@@ -1,10 +1,18 @@
-import { ddcVim, Denops, traq } from "../traqvim/deps.ts";
+import { ddcVim, ddcVimSource, Denops, ensureString, traq, vars } from "../traqvim/deps.ts";
 
 import { getStamps } from "../traqvim/model.ts";
+import { api } from "../traqvim/api.ts";
 
 type Params = Record<never, never>;
 
 export class Source extends ddcVim.BaseSource<Params> {
+  async onInit(args: ddcVimSource.OnInitArguments<Params>): Promise<void> {
+    const path = await vars.globals.get(args.denops, "traqvim#token_file_path");
+    ensureString(path);
+    api.tokenFilePath = path;
+    return Promise.resolve();
+  }
+
   override async gather(): Promise<ddcVim.Item[]> {
     const stamps: traq.Stamp[] = await getStamps();
     return stamps

--- a/denops/@ddc-sources/stamp.ts
+++ b/denops/@ddc-sources/stamp.ts
@@ -1,4 +1,11 @@
-import { ddcVim, ddcVimSource, Denops, ensureString, traq, vars } from "../traqvim/deps.ts";
+import {
+  ddcVim,
+  ddcVimSource,
+  Denops,
+  ensureString,
+  traq,
+  vars,
+} from "../traqvim/deps.ts";
 
 import { getStamps } from "../traqvim/model.ts";
 import { api } from "../traqvim/api.ts";

--- a/denops/@ddu-sources/channel.ts
+++ b/denops/@ddu-sources/channel.ts
@@ -1,12 +1,26 @@
-import { dduVim, Denops, helper } from "../traqvim/deps.ts";
+import {
+  dduVim,
+  dduVimSource,
+  Denops,
+  ensureString,
+  helper,
+  vars,
+} from "../traqvim/deps.ts";
 import { ActionData } from "../@ddu-kinds/channel.ts";
 import { channelsRecursive, searchChannelUUID } from "../traqvim/model.ts";
 import { Channel } from "../traqvim/type.d.ts";
+import { api } from "../traqvim/api.ts";
 
 type Params = Record<never, never>;
 
 export class Source extends dduVim.BaseSource<Params> {
   kind = "channel";
+  async onInit(args: dduVimSource.OnInitArguments<Params>): Promise<void> {
+    const path = await vars.globals.get(args.denops, "traqvim#token_file_path");
+    ensureString(path);
+    api.tokenFilePath = path;
+    return Promise.resolve();
+  }
   override gather(args: {
     denops: Denops;
     sourceOptions: dduVim.SourceOptions;

--- a/denops/@ddu-sources/channel_rec.ts
+++ b/denops/@ddu-sources/channel_rec.ts
@@ -1,4 +1,10 @@
-import { dduVim, dduVimSource, Denops, ensureString, vars } from "../traqvim/deps.ts";
+import {
+  dduVim,
+  dduVimSource,
+  Denops,
+  ensureString,
+  vars,
+} from "../traqvim/deps.ts";
 import { ActionData } from "../@ddu-kinds/channel.ts";
 import { channelsRecursive, getUnreadChannels } from "../traqvim/model.ts";
 import { Channel, UnreadChannel } from "../traqvim/type.d.ts";

--- a/denops/@ddu-sources/channel_rec.ts
+++ b/denops/@ddu-sources/channel_rec.ts
@@ -1,7 +1,8 @@
-import { dduVim, Denops } from "../traqvim/deps.ts";
+import { dduVim, dduVimSource, Denops, ensureString, vars } from "../traqvim/deps.ts";
 import { ActionData } from "../@ddu-kinds/channel.ts";
 import { channelsRecursive, getUnreadChannels } from "../traqvim/model.ts";
 import { Channel, UnreadChannel } from "../traqvim/type.d.ts";
+import { api } from "../traqvim/api.ts";
 
 type Params = {
   type: "all" | "unread";
@@ -9,6 +10,12 @@ type Params = {
 
 export class Source extends dduVim.BaseSource<Params> {
   kind = "channel";
+  async onInit(args: dduVimSource.OnInitArguments<Params>): Promise<void> {
+    const path = await vars.globals.get(args.denops, "traqvim#token_file_path");
+    ensureString(path);
+    api.tokenFilePath = path;
+    return Promise.resolve();
+  }
   gather(args: {
     denops: Denops;
     sourceParams: Params;

--- a/denops/traqvim/deps.ts
+++ b/denops/traqvim/deps.ts
@@ -13,4 +13,5 @@ export * as vars from "https://deno.land/x/denops_std@v4.0.0/variable/mod.ts";
 export * as helper from "https://deno.land/x/denops_std@v4.0.0/helper/mod.ts";
 export * as ddcVim from "https://deno.land/x/ddc_vim@v3.4.0/types.ts";
 export * as dduVim from "https://deno.land/x/ddu_vim@v1.13.0/types.ts";
+export * as dduVimSource from "https://deno.land/x/ddu_vim@v1.13.0/base/source.ts";
 export * as traq from "https://esm.sh/@traptitech/traq@3.11.0-3";

--- a/denops/traqvim/deps.ts
+++ b/denops/traqvim/deps.ts
@@ -12,6 +12,7 @@ export * as fn from "https://deno.land/x/denops_std@v4.0.0/function/mod.ts";
 export * as vars from "https://deno.land/x/denops_std@v4.0.0/variable/mod.ts";
 export * as helper from "https://deno.land/x/denops_std@v4.0.0/helper/mod.ts";
 export * as ddcVim from "https://deno.land/x/ddc_vim@v3.4.0/types.ts";
+export * as ddcVimSource from "https://deno.land/x/ddc_vim@v3.4.0/base/source.ts";
 export * as dduVim from "https://deno.land/x/ddu_vim@v1.13.0/types.ts";
 export * as dduVimSource from "https://deno.land/x/ddu_vim@v1.13.0/base/source.ts";
 export * as traq from "https://esm.sh/@traptitech/traq@3.11.0-3";


### PR DESCRIPTION
dduの読み込みを考慮するとapi用のトークンファイル読み込みをdenopsインスタンスを持ってる側でする必要があるっぽい

なんで、ddu側でもapiの初期化っぽいことをやるように