### PR TITLE
再描画時に既存の行が残っちゃうのを修正

### DIFF
--- a/autoload/traqvim.vim
+++ b/autoload/traqvim.vim
@@ -29,6 +29,7 @@ function! traqvim#draw_timeline(bufNum) abort
 		let start = end + 1
 		let index = index + 1
 	endfor
+	call deletebufline(a:bufNum, start, '$')
 	call setbufvar(a:bufNum, "&modifiable", 0)
 endfunction
 


### PR DESCRIPTION
SSIA

Close #58 

描画時に該当箇所より下部分の行を削除