### PR TITLE
メッセージ関連をコピーするオペレータとか追加

### DIFF
--- a/autoload/traqvim.vim
+++ b/autoload/traqvim.vim
@@ -150,3 +150,11 @@ function traqvim#yankMessageLink(t) abort
 	let messageLink = "https://q.trap.jp/messages/" . messageStart->get('id')
 	call setreg(v:register, messageLink)
 endfunction
+
+function traqvim#message_motion() abort
+	let position = traqvim#get_message()->get('position')
+	call cursor(position->get('start'), 1)
+	normal! V
+	call cursor(position->get('end'), 1)
+endfunction
+

--- a/autoload/traqvim.vim
+++ b/autoload/traqvim.vim
@@ -151,6 +151,23 @@ function traqvim#yankMessageLink(t) abort
 	call setreg(v:register, messageLink)
 endfunction
 
+function traqvim#registerYankMessageMarkdown() abort
+	let &opfunc = function('traqvim#yankMessageMarkdown')
+	return 'g@'
+endfunction
+
+function traqvim#yankMessageMarkdown(t) abort
+	if a:t != 'line'
+		return
+	endif
+	let messageStart = traqvim#get_message_buf(line("'["), bufnr('%'))
+	let messageEnd = traqvim#get_message_buf(line("']"), bufnr('%'))
+	if messageStart->get('id') != messageEnd->get('id')
+		return
+	endif
+	call setreg(v:register, messageStart->get('content'))
+endfunction
+
 function traqvim#message_motion() abort
 	let position = traqvim#get_message()->get('position')
 	call cursor(position->get('start'), 1)

--- a/autoload/traqvim.vim
+++ b/autoload/traqvim.vim
@@ -132,3 +132,21 @@ function! traqvim#message_next() abort
 	let next = b:channelTimeline[next_index]
 	call cursor([next.position["start"], 0])
 endfunction
+
+function traqvim#registerYankMessageLink() abort
+	let &opfunc = function('traqvim#yankMessageLink')
+	return 'g@'
+endfunction
+
+function traqvim#yankMessageLink(t) abort
+	if a:t != 'line'
+		return
+	endif
+	let messageStart = traqvim#get_message_buf(line("'["), bufnr('%'))
+	let messageEnd = traqvim#get_message_buf(line("']"), bufnr('%'))
+	if messageStart->get('id') != messageEnd->get('id')
+		return
+	endif
+	let messageLink = "https://q.trap.jp/messages/" . messageStart->get('id')
+	call setreg(v:register, messageLink)
+endfunction

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -98,3 +98,12 @@ export const actionOpenActivity = async (
     bufN,
   );
 };
+
+export const actionYankMessageLink = async (
+  denops: Denops,
+  message: Message,
+): Promise<void> => {
+  const messageLink = `https://q.trap.jp/messages/${message.id}`;
+  await fn.setreg(denops, '"', messageLink);
+  await helper.echo(denops, "Yanked message link");
+};

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -107,3 +107,11 @@ export const actionYankMessageLink = async (
   await fn.setreg(denops, '"', messageLink);
   await helper.echo(denops, "Yanked message link");
 };
+
+export const actionYankMessageMarkdown = async (
+  denops: Denops,
+  message: Message,
+): Promise<void> => {
+  await fn.setreg(denops, '"', message.content);
+  await helper.echo(denops, "Yanked message markdown");
+};

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -22,6 +22,7 @@ import {
   actionOpenActivity,
   actionOpenChannel,
   actionYankMessageLink,
+  actionYankMessageMarkdown,
 } from "./action.ts";
 import { ChannelMessageBuffer, Message } from "./type.d.ts";
 import { api } from "./api.ts";
@@ -253,6 +254,10 @@ export async function main(denops: Denops) {
     async yankMessageLink(message: unknown): Promise<unknown> {
       // ensureでの型チェックの仕方分からんから、とりあえずasで:awoo:
       await actionYankMessageLink(denops, message as Message);
+      return Promise.resolve();
+    },
+    async yankMessageMarkdown(message: unknown): Promise<unknown> {
+      await actionYankMessageMarkdown(denops, message as Message);
       return Promise.resolve();
     },
   };

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -21,6 +21,7 @@ import {
   actionForwardChannelMessage,
   actionOpenActivity,
   actionOpenChannel,
+  actionYankMessageLink,
 } from "./action.ts";
 import { ChannelMessageBuffer, Message } from "./type.d.ts";
 import { api } from "./api.ts";
@@ -248,6 +249,11 @@ export async function main(denops: Denops) {
       await sendMessage(channelID, content);
       await denops.cmd(":bdelete");
       return;
+    },
+    async yankMessageLink(message: unknown): Promise<unknown> {
+      // ensureでの型チェックの仕方分からんから、とりあえずasで:awoo:
+      await actionYankMessageLink(denops, message as Message);
+      return Promise.resolve();
     },
   };
 }

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -14,7 +14,7 @@ nnoremap <buffer><silent> <Plug>(traqvim-prev)
 " 			\ "<Cmd><SID>let &opfunc=function('s:registerYankMessageLink')<CR>g@"
 
 nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
-			\ "<Cmd>let &opfunc=function('traqvim#registerYankMessageLink')<CR>g@"
+			\ traqvim#registerYankMessageLink()
 
 omap <buffer> im
 			\ <Plug>(traqvim-message-motion)
@@ -24,14 +24,7 @@ nmap <buffer> <LocalLeader>y
 
 " 自作モーションの作成
 onoremap <silent> <Plug>(traqvim-message-motion)
-			\ <SID>:<C-u>call s:message_motion()<CR>
-
-function s:message_motion() abort
-	let position = traqvim#get_message()->get('position')
-	call cursor(position->get('start'), 1)
-	normal! V
-	call cursor(position->get('end'), 1)
-endfunction
+			\ :<C-u>call traqvim#message_motion()<CR>
 
 command! -buffer -nargs=0 TraqYankMessageLink
 			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -12,6 +12,8 @@ nnoremap <buffer><silent> <Plug>(traqvim-prev)
 
 command! -buffer -nargs=0 TraqYankMessageLink
 			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])
+command! -buffer -nargs=0 TraqYankMessageMarkdown
+			\ call denops#request('traqvim', 'yankMessageMarkdown', [traqvim#get_message()])
 
 " filetypeがtraqvimの時かつ、ウィンドウのサイズが変更された時だけ実行
 

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -12,6 +12,8 @@ nnoremap <buffer><silent> <Plug>(traqvim-prev)
 
 nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
 			\ traqvim#registerYankMessageLink()
+nnoremap <buffer><expr> <Plug>(traqvim-yank-message-markdown-operator)
+			\ traqvim#registerYankMessageMarkdown()
 
 onoremap <silent> <Plug>(traqvim-message-motion)
 			\ :<C-u>call traqvim#message_motion()<CR>
@@ -21,6 +23,9 @@ omap <buffer> im
 
 nmap <buffer> <LocalLeader>y
 			\ <Plug>(traqvim-yank-message-link-operator)
+
+nmap <buffer> <LocalLeader>Y
+			\ <Plug>(traqvim-yank-message-markdown-operator)
 
 command! -buffer -nargs=0 TraqYankMessageLink
 			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -10,6 +10,9 @@ nnoremap <buffer><silent> <Plug>(traqvim-next)
 nnoremap <buffer><silent> <Plug>(traqvim-prev)
 			\ <Cmd>call traqvim#message_prev()<CR>
 
+command! -buffer -nargs=0 TraqYankMessageLink
+			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])
+
 " filetypeがtraqvimの時かつ、ウィンドウのサイズが変更された時だけ実行
 
 augroup traqvim

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -10,21 +10,17 @@ nnoremap <buffer><silent> <Plug>(traqvim-next)
 nnoremap <buffer><silent> <Plug>(traqvim-prev)
 			\ <Cmd>call traqvim#message_prev()<CR>
 
-" nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
-" 			\ "<Cmd><SID>let &opfunc=function('s:registerYankMessageLink')<CR>g@"
-
 nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
 			\ traqvim#registerYankMessageLink()
+
+onoremap <silent> <Plug>(traqvim-message-motion)
+			\ :<C-u>call traqvim#message_motion()<CR>
 
 omap <buffer> im
 			\ <Plug>(traqvim-message-motion)
 
 nmap <buffer> <LocalLeader>y
 			\ <Plug>(traqvim-yank-message-link-operator)
-
-" 自作モーションの作成
-onoremap <silent> <Plug>(traqvim-message-motion)
-			\ :<C-u>call traqvim#message_motion()<CR>
 
 command! -buffer -nargs=0 TraqYankMessageLink
 			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -10,6 +10,29 @@ nnoremap <buffer><silent> <Plug>(traqvim-next)
 nnoremap <buffer><silent> <Plug>(traqvim-prev)
 			\ <Cmd>call traqvim#message_prev()<CR>
 
+" nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
+" 			\ "<Cmd><SID>let &opfunc=function('s:registerYankMessageLink')<CR>g@"
+
+nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
+			\ "<Cmd>let &opfunc=function('traqvim#registerYankMessageLink')<CR>g@"
+
+omap <buffer> im
+			\ <Plug>(traqvim-message-motion)
+
+nmap <buffer> <LocalLeader>y
+			\ <Plug>(traqvim-yank-message-link-operator)
+
+" 自作モーションの作成
+onoremap <silent> <Plug>(traqvim-message-motion)
+			\ <SID>:<C-u>call s:message_motion()<CR>
+
+function s:message_motion() abort
+	let position = traqvim#get_message()->get('position')
+	call cursor(position->get('start'), 1)
+	normal! V
+	call cursor(position->get('end'), 1)
+endfunction
+
 command! -buffer -nargs=0 TraqYankMessageLink
 			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])
 command! -buffer -nargs=0 TraqYankMessageMarkdown


### PR DESCRIPTION
オペレータとかモーションでヤンクできるようにしたし、それようのアクションとかも追加した

これを元にさらに便利なアクション作れそう

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new commands for yanking message links and message markdown content in the `traqvim` plugin.
  - Users can now easily copy message links and markdown to the clipboard with added key mappings.

- **Enhancements**
  - Improved message handling capabilities within the plugin for a more efficient workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->