### PR TITLE
バッファの名前をそれっぽく統一させた

### DIFF
--- a/autoload/traqvim.vim
+++ b/autoload/traqvim.vim
@@ -1,6 +1,8 @@
 " channelPath: '\#gps/times/kamecha'
-function! traqvim#make_buffer(channelPath, option) abort
-	let buf_name = a:channelPath
+"なんかバッファを作る処理(bufnrとか)と
+"バッファを開く処理(:bufferとか)を分けて実装したほうが良さそう
+function! traqvim#make_buffer(buf_name) abort
+	let buf_name = a:buf_name
 	let buf_offset = 1
 	while bufexists(buf_name[1:])
 		if buf_name =~# ')$'
@@ -10,8 +12,7 @@ function! traqvim#make_buffer(channelPath, option) abort
 			let buf_name = buf_name . '(1)'
 		endif
 	endwhile
-	noswapfile exe a:option buf_name
-	let buf_num = bufnr(buf_name)
+	let buf_num = bufnr(buf_name, 1)
 	return buf_num
 endfunction
 

--- a/denops/@ddu-kinds/channel.ts
+++ b/denops/@ddu-kinds/channel.ts
@@ -26,8 +26,6 @@ export class Kind extends dduVim.BaseKind<Params> {
       actionParams: unknown;
       items: dduVim.DduItem[];
     }) => {
-      const params = args.actionParams as OpenParams;
-      const openCommand = params.command ?? "edit";
       for (const item of args.items) {
         if (!item.action) {
           continue;
@@ -47,7 +45,11 @@ export class Kind extends dduVim.BaseKind<Params> {
           until: new Date().toISOString(),
           order: "desc",
         };
-        await actionOpenChannel(args.denops, timelineOption, openCommand);
+        const params = args.actionParams as OpenParams;
+        if (params.command) {
+          await args.denops.cmd(params.command);
+        }
+        await actionOpenChannel(args.denops, timelineOption);
       }
       return dduVim.ActionFlags.None;
     },

--- a/denops/@ddu-sources/channel.ts
+++ b/denops/@ddu-sources/channel.ts
@@ -7,7 +7,7 @@ import {
   vars,
 } from "../traqvim/deps.ts";
 import { ActionData } from "../@ddu-kinds/channel.ts";
-import { channelsRecursive, searchChannelUUID } from "../traqvim/model.ts";
+import { channelsRecursive } from "../traqvim/model.ts";
 import { Channel } from "../traqvim/type.d.ts";
 import { api } from "../traqvim/api.ts";
 
@@ -27,17 +27,12 @@ export class Source extends dduVim.BaseSource<Params> {
   }): ReadableStream<dduVim.Item<ActionData>[]> {
     return new ReadableStream({
       async start(controller) {
-        const rootPath = args.sourceOptions.path;
-        // #gps/times/kamecha から対象のChannelIDを抽出
-        let rootId: string = rootPath === "VtraQ" ? "VtraQ" : "";
-        if (rootId === "") {
-          rootId = await searchChannelUUID(rootPath);
-        }
+        const rootId = args.sourceOptions.path;
         const tree = async (rootId: string) => {
           const items: dduVim.Item<ActionData>[] = [];
           const channels: Channel[] = await channelsRecursive();
           // 一番上の階層対応
-          if (rootId === "VtraQ") {
+          if (rootId === "") {
             const parentChannels = channels.filter((channel: Channel) => {
               return channel.parentId === null;
             });
@@ -48,7 +43,7 @@ export class Source extends dduVim.BaseSource<Params> {
                   id: channel.id,
                 },
                 isTree: true,
-                treePath: channel.path,
+                treePath: channel.id,
               });
             });
             return items;
@@ -74,7 +69,7 @@ export class Source extends dduVim.BaseSource<Params> {
                 id: childrenChannel.id,
               },
               isTree: childrenChannel.children.length !== 0,
-              treePath: childrenChannel.path,
+              treePath: childrenChannel.id,
             });
           });
           return items;

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -33,7 +33,13 @@ export const actionOpenChannel = async (
   };
   const open = openCommand ?? "edit";
   const bufN = bufNum ??
-    await denops.call("traqvim#make_buffer", escapedChannelPath, open);
+    await denops.call("traqvim#make_buffer", escapedChannelPath);
+  // const open = openCommand ?? "enew";
+  if ( openCommand ) {
+    await denops.cmd(openCommand);
+  }
+  // await denops.cmd(open);
+  await denops.cmd(`noswapfile buffer ${bufN}`);
   await vars.buffers.set(denops, "channelID", channelBufferVars.channelID);
   await vars.buffers.set(denops, "channelPath", channelBufferVars.channelPath);
   await vars.buffers.set(
@@ -155,7 +161,8 @@ export const actionOpenActivity = async (
 ): Promise<void> => {
   const activityList: Message[] = await activity();
   const bufN = bufNum ??
-    await denops.call("traqvim#make_buffer", "Activity", "edit");
+    await denops.call("traqvim#make_buffer", "Activity");
+  await denops.cmd(`noswapfile buffer ${bufN}`);
   await vars.buffers.set(
     denops,
     "channelTimeline",

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -13,7 +13,6 @@ import {
 export const actionOpenChannel = async (
   denops: Denops,
   channelMessageOptions: channelMessageOptions,
-  openCommand?: string,
   bufNum?: number,
 ): Promise<void> => {
   helper.echo(denops, "actionOpenChannel");
@@ -34,11 +33,6 @@ export const actionOpenChannel = async (
   };
   const bufN = bufNum ??
     await denops.call("traqvim#make_buffer", escapedChannelPath);
-  // const open = openCommand ?? "enew";
-  if ( openCommand ) {
-    await denops.cmd(openCommand);
-  }
-  // await denops.cmd(open);
   await denops.cmd(`noswapfile buffer ${bufN}`);
   await vars.buffers.set(denops, "channelID", channelBufferVars.channelID);
   await vars.buffers.set(denops, "channelPath", channelBufferVars.channelPath);

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -32,7 +32,6 @@ export const actionOpenChannel = async (
     channelPath: escapedChannelPath,
     channelTimeline: timeline,
   };
-  const open = openCommand ?? "edit";
   const bufN = bufNum ??
     await denops.call("traqvim#make_buffer", escapedChannelPath);
   // const open = openCommand ?? "enew";

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -1,4 +1,4 @@
-import { Denops, ensureArray, fn, helper, vars } from "./deps.ts";
+import { Denops, bufname, ensureArray, fn, helper, vars } from "./deps.ts";
 import { ChannelBuffer, Message } from "./type.d.ts";
 import {
   activity,
@@ -22,10 +22,11 @@ export const actionOpenChannel = async (
     helper.echoerr(denops, "channelPath is undefined");
     return;
   }
-  const escapedChannelPath = channelMessageOptions.channelPath.replace(
-    "#",
-    "\\#",
-  );
+  const escapedChannelPath = bufname.format({
+    scheme: "VtraQ",
+    expr: "channel",
+    fragment: channelMessageOptions.channelPath.replace("#", ""),
+  });
   const channelBufferVars: ChannelBuffer = {
     channelID: channelMessageOptions.id,
     channelPath: escapedChannelPath,
@@ -160,8 +161,12 @@ export const actionOpenActivity = async (
   bufNum?: number,
 ): Promise<void> => {
   const activityList: Message[] = await activity();
+  const activityPath = bufname.format({
+    scheme: "VtraQ",
+    expr: "Activity",
+  });
   const bufN = bufNum ??
-    await denops.call("traqvim#make_buffer", "Activity");
+    await denops.call("traqvim#make_buffer", activityPath);
   await denops.cmd(`noswapfile buffer ${bufN}`);
   await vars.buffers.set(
     denops,

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -1,4 +1,4 @@
-import { Denops, bufname, ensureArray, fn, helper, vars } from "./deps.ts";
+import { bufname, Denops, ensureArray, fn, helper, vars } from "./deps.ts";
 import { ChannelBuffer, Message } from "./type.d.ts";
 import {
   activity,

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -23,7 +23,7 @@ export const actionOpenChannel = async (
   }
   const escapedChannelPath = bufname.format({
     scheme: "VtraQ",
-    expr: "channel",
+    expr: "/Channel",
     fragment: channelMessageOptions.channelPath.replace("#", ""),
   });
   const channelBufferVars: ChannelBuffer = {
@@ -156,7 +156,7 @@ export const actionOpenActivity = async (
   const activityList: Message[] = await activity();
   const activityPath = bufname.format({
     scheme: "VtraQ",
-    expr: "Activity",
+    expr: "/Activity",
   });
   const bufN = bufNum ??
     await denops.call("traqvim#make_buffer", activityPath);

--- a/denops/traqvim/deps.ts
+++ b/denops/traqvim/deps.ts
@@ -11,6 +11,7 @@ export type { Denops } from "https://deno.land/x/denops_std@v4.0.0/mod.ts";
 export * as fn from "https://deno.land/x/denops_std@v4.0.0/function/mod.ts";
 export * as vars from "https://deno.land/x/denops_std@v4.0.0/variable/mod.ts";
 export * as helper from "https://deno.land/x/denops_std@v4.0.0/helper/mod.ts";
+export * as bufname from "https://deno.land/x/denops_std@v4.0.0/bufname/mod.ts";
 export * as ddcVim from "https://deno.land/x/ddc_vim@v3.4.0/types.ts";
 export * as ddcVimSource from "https://deno.land/x/ddc_vim@v3.4.0/base/source.ts";
 export * as dduVim from "https://deno.land/x/ddu_vim@v1.13.0/types.ts";

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -234,12 +234,12 @@ export async function main(denops: Denops) {
         fragment: bufname.parse(bufName).fragment,
       });
       // bufferが下に表示されるようoptionを設定し元に戻す
-      await fn.setbufvar(denops, bufNum, "&splitbelow", 1);
       const messageBufNum = await denops.call(
         "traqvim#make_buffer",
         messageBufName,
-        "new",
       );
+      await fn.setbufvar(denops, bufNum, "&splitbelow", 1);
+      await denops.cmd(`split +buffer\\ ${messageBufNum}`);
       await fn.setbufvar(denops, bufNum, "&splitbelow", 0);
       await fn.setbufvar(
         denops,
@@ -303,7 +303,6 @@ export async function main(denops: Denops) {
     },
     async messageEditOpen(bufNum: unknown, message: unknown): Promise<unknown> {
       ensureNumber(bufNum);
-      await fn.setbufvar(denops, bufNum, "&splitbelow", 1);
       const bufName = await fn.bufname(denops, bufNum);
       const messageBufName = bufname.format({
         scheme: bufname.parse(bufName).scheme,
@@ -316,9 +315,11 @@ export async function main(denops: Denops) {
       const messageBufNum = await denops.call(
         "traqvim#make_buffer",
         messageBufName,
-        "new",
       );
       ensureNumber(messageBufNum);
+      await fn.setbufvar(denops, bufNum, "&splitbelow", 1);
+      await denops.cmd(`split +buffer\\ ${messageBufNum}`);
+      await fn.setbufvar(denops, bufNum, "&splitright", 0);
       // 既存メッセージの内容を描画しておく
       await fn.setbufline(
         denops,
@@ -326,7 +327,6 @@ export async function main(denops: Denops) {
         1,
         (message as Message).content.split("\n"),
       );
-      await fn.setbufvar(denops, bufNum, "&splitright", 0);
       await fn.setbufvar(
         denops,
         messageBufNum,

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -141,7 +141,7 @@ export async function main(denops: Denops) {
           until: new Date().toISOString(),
           order: "desc",
         };
-        actionOpenChannel(denops, timelineOption, undefined, bufNum);
+        actionOpenChannel(denops, timelineOption, bufNum);
       }
       return;
     },

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -8,6 +8,7 @@ import {
 } from "./model.ts";
 import {
   Denops,
+  bufname,
   ensureArray,
   ensureNumber,
   ensureString,
@@ -228,7 +229,14 @@ export async function main(denops: Denops) {
       const channelMessageVars: ChannelMessageBuffer = {
         channelID: channelID,
       };
-      const messageBufName = "Message" + bufName.replace("#", "\\#");
+      const messageBufName = bufname.format({
+        scheme: bufname.parse(bufName).scheme,
+        expr: "Message",
+        params: {
+          type: "open",
+        },
+        fragment: bufname.parse(bufName).fragment,
+      });
       // bufferが下に表示されるようoptionを設定し元に戻す
       await fn.setbufvar(denops, bufNum, "&splitbelow", 1);
       const messageBufNum = await denops.call(
@@ -300,9 +308,18 @@ export async function main(denops: Denops) {
     async messageEditOpen(bufNum: unknown, message: unknown): Promise<unknown> {
       ensureNumber(bufNum);
       await fn.setbufvar(denops, bufNum, "&splitbelow", 1);
+      const bufName = await fn.bufname(denops, bufNum);
+      const messageBufName = bufname.format({
+        scheme: bufname.parse(bufName).scheme,
+        expr: "Message",
+        params: {
+          type: "edit",
+        },
+        fragment: bufname.parse(bufName).fragment,
+      });
       const messageBufNum = await denops.call(
         "traqvim#make_buffer",
-        "Edit",
+        messageBufName,
         "new",
       );
       ensureNumber(messageBufNum);

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -4,7 +4,6 @@ import {
   channelTimeline,
   homeChannelId,
   homeChannelPath,
-  searchChannelUUID,
   sendMessage,
 } from "./model.ts";
 import {
@@ -102,11 +101,12 @@ export async function main(denops: Denops) {
       ensureString(args);
       // argsが"#gps/times/kamecha(1)"のようになっていた場合"(1)"を削除する
       const channelPath = args.replace(/\(\d+\)$/, "");
-      const channelUUID = await searchChannelUUID(channelPath);
+      const channelID = await vars.buffers.get(denops, "channelID");
+      ensureString(channelID);
       const limit = await vars.globals.get(denops, "traqvim#fetch_limit");
       ensureNumber(limit);
       const timelineOption: channelMessageOptions = {
-        id: channelUUID,
+        id: channelID,
         channelPath: channelPath,
         limit: limit,
         until: new Date().toISOString(),
@@ -129,11 +129,12 @@ export async function main(denops: Denops) {
         // バッファが"#gps/times/kamecha(1)"のように"(1)"がついている場合、
         // それを削除する
         const bufNameWithoutNumber = bufName.replace(/\(\d+\)$/, "");
-        const channelUUID = await searchChannelUUID(bufNameWithoutNumber);
+        const channelID = await vars.buffers.get(denops, "channelID");
+        ensureString(channelID);
         const limit = await vars.globals.get(denops, "traqvim#fetch_limit");
         ensureNumber(limit);
         const timelineOption: channelMessageOptions = {
-          id: channelUUID,
+          id: channelID,
           channelPath: bufNameWithoutNumber,
           limit: limit,
           until: new Date().toISOString(),
@@ -151,12 +152,13 @@ export async function main(denops: Denops) {
         const timeline = await vars.buffers.get(denops, "channelTimeline");
         ensureArray<Message>(timeline);
         const bufNameWithoutNumber = bufName.replace(/\(\d+\)$/, "");
-        const channelUUID = await searchChannelUUID(bufNameWithoutNumber);
+        const channelID = await vars.buffers.get(denops, "channelID");
+        ensureString(channelID);
         const limit = await vars.globals.get(denops, "traqvim#fetch_limit");
         ensureNumber(limit);
         // 最後のメッセージの内容
         const timelineOption: channelMessageOptions = {
-          id: channelUUID,
+          id: channelID,
           channelPath: bufNameWithoutNumber,
           limit: limit,
           since: new Date(timeline[timeline.length - 1].createdAt)
@@ -187,12 +189,13 @@ export async function main(denops: Denops) {
         const timeline = await vars.buffers.get(denops, "channelTimeline");
         ensureArray<Message>(timeline);
         const bufNameWithoutNumber = bufName.replace(/\(\d+\)$/, "");
-        const channelUUID = await searchChannelUUID(bufNameWithoutNumber);
+        const channelID = await vars.buffers.get(denops, "channelID");
+        ensureString(channelID);
         const limit = await vars.globals.get(denops, "traqvim#fetch_limit");
         ensureNumber(limit);
         // 最後のメッセージの内容
         const timelineOption: channelMessageOptions = {
-          id: channelUUID,
+          id: channelID,
           channelPath: bufNameWithoutNumber,
           limit: limit,
           until: new Date(timeline[0].createdAt).toISOString(),

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -220,10 +220,6 @@ export async function main(denops: Denops) {
     async messageOpen(bufNum: unknown, bufName: unknown): Promise<unknown> {
       ensureNumber(bufNum);
       ensureString(bufName);
-      // bufNameの先頭に#がついていなければ、何もしない
-      if (bufName[0] !== "#") {
-        return;
-      }
       const channelID = await fn.getbufvar(denops, bufNum, "channelID");
       ensureString(channelID);
       const channelMessageVars: ChannelMessageBuffer = {

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -7,8 +7,8 @@ import {
   sendMessage,
 } from "./model.ts";
 import {
-  Denops,
   bufname,
+  Denops,
   ensureArray,
   ensureNumber,
   ensureString,

--- a/denops/traqvim/model.ts
+++ b/denops/traqvim/model.ts
@@ -15,51 +15,6 @@ export type channelMessageOptions = {
   order?: "asc" | "desc";
 };
 
-// channelPathに一致するchannelのUUIDを返す
-// channelPathは#で始まる
-export async function searchChannelUUID(channelPath: string): Promise<string> {
-  // channelPathの先頭が#で始まっているかのチェック
-  if (!channelPath.startsWith("#")) {
-    throw new Error("channelPath must start with #");
-  }
-  // channelPathの先頭の#を削除
-  const channelPathWituoutSharp = channelPath.slice(1);
-  // channelPathの先頭の#を削除したものを/で分割
-  const channelPathSplited = channelPathWituoutSharp.split("/");
-  const channelsRes = await api.api.getChannels();
-  // const channelsJson = await channelsPromise.json();
-  const channels = channelsRes.data.public;
-  let channelUUID = "";
-  const searchDFS = (
-    baseChannels: traq.Channel[],
-    name: string[],
-  ): string | undefined => {
-    if (name.length === 0) {
-      return channelUUID;
-    }
-    const channel = baseChannels.find((channel: traq.Channel) =>
-      channel.name === name[0]
-    );
-    if (!channel) {
-      return undefined;
-    }
-    channelUUID = channel.id;
-    const children = channels.filter((channel: traq.Channel) =>
-      channel.parentId === channelUUID
-    );
-    return searchDFS(children, name.slice(1));
-  };
-  // channelsから親がいないchannelを探す
-  const rootChannels = channels.filter((channel: traq.Channel) =>
-    channel.parentId === null
-  );
-  const result = searchDFS(rootChannels, channelPathSplited);
-  if (!result) {
-    throw new Error("channel not found");
-  }
-  return result;
-}
-
 const makeChannelPath = (
   channels: traq.Channel[],
   channel: traq.Channel,


### PR DESCRIPTION
- channelのPath→idの順番を廃止して、idを所有するように
- チャンネルbufferの作成と表示を分離
- bufnameモジュールを使用した名前を使用
- 変更の過程で不要になった箇所の削除
- message bufferを開く際も、buffer作成&開くを分離
- refater:dduのkind
- dduでpathにidを持たせるように変更
- 関数変更による引数間違いを修正
- refater: buffer nameの統一感出したかった


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the buffer creation process with streamlined arguments for better usability.
  - Improved command handling in the plugin for opening channels and activities.

- **Refactor**
  - Simplified the logic for setting `rootId` and `treePath` properties.
  - Optimized buffer management and retrieval of channel IDs.
  - Removed unnecessary parameters and variables to clarify action functions.

- **Chores**
  - Updated dependencies with a new import for improved functionality.

- **Bug Fixes**
  - Fixed issues related to buffer naming and command execution that could affect user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->