### PR TITLE
アクティビティでリロードするとエラるのを修正

### DIFF
--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -123,11 +123,8 @@ export async function main(denops: Denops) {
       // バッファ番号は被らないが、バッファ名は被る可能性がある
       ensureNumber(bufNum);
       ensureString(bufName);
-      const activityBufName = bufname.format({
-        scheme: "VtraQ",
-        expr: "/Activity",
-      });
-      if (bufName === activityBufName) {
+      const bufnameParsed = bufname.parse(bufName);
+      if (bufnameParsed.expr === "/Activity") {
         actionOpenActivity(denops, bufNum);
       } else {
         // バッファが"#gps/times/kamecha(1)"のように"(1)"がついている場合、

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -129,7 +129,8 @@ export async function main(denops: Denops) {
       } else {
         // バッファが"#gps/times/kamecha(1)"のように"(1)"がついている場合、
         // それを削除する
-        const bufNameWithoutNumber = bufName.replace(/\(\d+\)$/, "");
+        const bufNameWithoutNumber =
+          bufnameParsed.fragment?.replace(/\(\d+\)$/, "") || "";
         const channelID = await vars.buffers.get(denops, "channelID");
         ensureString(channelID);
         const limit = await vars.globals.get(denops, "traqvim#fetch_limit");

--- a/denops/traqvim/main.ts
+++ b/denops/traqvim/main.ts
@@ -123,7 +123,11 @@ export async function main(denops: Denops) {
       // バッファ番号は被らないが、バッファ名は被る可能性がある
       ensureNumber(bufNum);
       ensureString(bufName);
-      if (bufName === "Activity") {
+      const activityBufName = bufname.format({
+        scheme: "VtraQ",
+        expr: "/Activity",
+      });
+      if (bufName === activityBufName) {
         actionOpenActivity(denops, bufNum);
       } else {
         // バッファが"#gps/times/kamecha(1)"のように"(1)"がついている場合、


### PR DESCRIPTION
バッファ名で表示しているのがチャンネルかアクテビティかを判断して、仕分けるように

重複チャンネルを見分け方とかを統一したいかなぁ