### PR TITLE
デフォルトキーマップを廃止して色々整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ autocmd FileType traqvim call s:traqvim_setting()
 
 function s:traqvim_setting()
 	omap <buffer> im
-				\ <Plug>(traqvim-message-motion)
+				\ <Plug>(traqvim-motion-message)
 	nmap <buffer> <LocalLeader>y
-				\ <Plug>(traqvim-yank-message-link-operator)
+				\ <Plug>(traqvim-operator-message-yank-link)
 	nmap <buffer> <LocalLeader>Y
-				\ <Plug>(traqvim-yank-message-markdown-operator)
+				\ <Plug>(traqvim-operator-message-yank-markdown)
 	nmap <buffer> <LocalLeader>d
-				\ <Plug>(traqvim-delete-message-operator)
+				\ <Plug>(traqvim-operator-message-delete)
 	nmap <buffer> <LocalLeader>p
-				\ <Plug>(traqvim-toggle-pin-operator)
+				\ <Plug>(traqvim-operator-pin-toggle)
 endfunction
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ ddu-ui-filer
 ddcとの連携
 ![image](https://user-images.githubusercontent.com/50443168/221398079-da91a873-5f8d-4c5a-af1c-650e4b88e09b.png)
 
+## 設定
+
+```vim
+" for keymap
+
+autocmd FileType traqvim call s:traqvim_setting()
+
+function s:traqvim_setting()
+	omap <buffer> im
+				\ <Plug>(traqvim-message-motion)
+	nmap <buffer> <LocalLeader>y
+				\ <Plug>(traqvim-yank-message-link-operator)
+	nmap <buffer> <LocalLeader>Y
+				\ <Plug>(traqvim-yank-message-markdown-operator)
+	nmap <buffer> <LocalLeader>d
+				\ <Plug>(traqvim-delete-message-operator)
+	nmap <buffer> <LocalLeader>p
+				\ <Plug>(traqvim-toggle-pin-operator)
+endfunction
+```
+
 ## 今後の展望
 
 WebSocketとか実装して、手動リロードしなくてもいいようにしたいなぁ...

--- a/doc/traqvim.jax
+++ b/doc/traqvim.jax
@@ -101,6 +101,22 @@ g:traqvim#token_file_path
 <Plug>(traqvim-prev)				    *<Plug>(traqvim-prev)*
     前のメッセージへカーソルを移動させます
 
+<Plug>(traqvim-message-motion)			    *<Plug>(traqvim-message-motion)*
+    カーソル下の該当メッセージの始まり・終わりを選択します
+    レイアウトで表示されるものが選択されます
+
+<Plug>(traqvim-yank-message-link-operator)	    *<Plug>(traqvim-yank-message-link-operator)*
+    該当メッセージのリンクをヤンクします
+
+<Plug>(traqvim-yank-message-markdown-operator)	    *<Plug>(traqvim-yank-message-markdown-operator)*
+    該当メッセージのリンクをマークダウン形式でヤンクします
+
+<Plug>(traqvim-delete-message-operator)		    *<Plug>(traqvim-delete-message-operator)*
+    該当メッセージを削除します
+
+<Plug>(traqvim-toggle-pin-operator)		    *<Plug>(traqvim-toggle-pin-operator)*
+    該当メッセージのピンをトグルします
+
 ------------------------------------------------------------------------------
 レイアウト					*traqvim-channel-layout*
 

--- a/doc/traqvim.jax
+++ b/doc/traqvim.jax
@@ -101,20 +101,20 @@ g:traqvim#token_file_path
 <Plug>(traqvim-prev)				    *<Plug>(traqvim-prev)*
     前のメッセージへカーソルを移動させます
 
-<Plug>(traqvim-message-motion)			    *<Plug>(traqvim-message-motion)*
+<Plug>(traqvim-motion-message)			    *<Plug>(traqvim-motion-message)*
     カーソル下の該当メッセージの始まり・終わりを選択します
     レイアウトで表示されるものが選択されます
 
-<Plug>(traqvim-yank-message-link-operator)	    *<Plug>(traqvim-yank-message-link-operator)*
+<Plug>(traqvim-operator-message-yank-link)	    *<Plug>(traqvim-operator-message-yank-link)*
     該当メッセージのリンクをヤンクします
 
-<Plug>(traqvim-yank-message-markdown-operator)	    *<Plug>(traqvim-yank-message-markdown-operator)*
+<Plug>(traqvim-operator-message-yank-markdown)	    *<Plug>(traqvim-operator-message-yank-markdown)*
     該当メッセージのリンクをマークダウン形式でヤンクします
 
-<Plug>(traqvim-delete-message-operator)		    *<Plug>(traqvim-delete-message-operator)*
+<Plug>(traqvim-operator-message-delete)		    *<Plug>(traqvim-operator-message-delete)*
     該当メッセージを削除します
 
-<Plug>(traqvim-toggle-pin-operator)		    *<Plug>(traqvim-toggle-pin-operator)*
+<Plug>(traqvim-operator-pin-toggle)		    *<Plug>(traqvim-operator-pin-toggle)*
     該当メッセージのピンをトグルします
 
 ------------------------------------------------------------------------------

--- a/ftplugin/traqvim-message.vim
+++ b/ftplugin/traqvim-message.vim
@@ -1,2 +1,0 @@
-nnoremap <buffer><silent> s
-			\ :TraqMessageSend<CR>

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -22,7 +22,7 @@ nnoremap <buffer><expr> <Plug>(traqvim-delete-message-operator)
 nnoremap <buffer><expr> <Plug>(traqvim-toggle-pin-operator)
 			\ traqvim#registerTogglePin()
 
-onoremap <silent> <Plug>(traqvim-message-motion)
+onoremap <buffer><silent> <Plug>(traqvim-message-motion)
 			\ :<C-u>call traqvim#message_motion()<CR>
 
 command! -buffer -nargs=0 TraqYankMessageLink

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -13,16 +13,16 @@ nnoremap <buffer><silent> <Plug>(traqvim-next)
 nnoremap <buffer><silent> <Plug>(traqvim-prev)
 			\ <Cmd>call traqvim#message_prev()<CR>
 
-nnoremap <buffer><expr> <Plug>(traqvim-yank-message-link-operator)
+nnoremap <buffer><expr> <Plug>(traqvim-operator-message-yank-link)
 			\ traqvim#registerYankMessageLink()
-nnoremap <buffer><expr> <Plug>(traqvim-yank-message-markdown-operator)
+nnoremap <buffer><expr> <Plug>(traqvim-operator-message-yank-markdown)
 			\ traqvim#registerYankMessageMarkdown()
-nnoremap <buffer><expr> <Plug>(traqvim-delete-message-operator)
+nnoremap <buffer><expr> <Plug>(traqvim-operator-message-delete)
 			\ traqvim#registerDeleteMessage()
-nnoremap <buffer><expr> <Plug>(traqvim-toggle-pin-operator)
+nnoremap <buffer><expr> <Plug>(traqvim-operator-pin-toggle)
 			\ traqvim#registerTogglePin()
 
-onoremap <buffer><silent> <Plug>(traqvim-message-motion)
+onoremap <buffer><silent> <Plug>(traqvim-motion-message)
 			\ :<C-u>call traqvim#message_motion()<CR>
 
 command! -buffer -nargs=0 TraqYankMessageLink

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -25,21 +25,6 @@ nnoremap <buffer><expr> <Plug>(traqvim-toggle-pin-operator)
 onoremap <silent> <Plug>(traqvim-message-motion)
 			\ :<C-u>call traqvim#message_motion()<CR>
 
-omap <buffer> im
-			\ <Plug>(traqvim-message-motion)
-
-nmap <buffer> <LocalLeader>y
-			\ <Plug>(traqvim-yank-message-link-operator)
-
-nmap <buffer> <LocalLeader>Y
-			\ <Plug>(traqvim-yank-message-markdown-operator)
-
-nmap <buffer> <LocalLeader>d
-			\ <Plug>(traqvim-delete-message-operator)
-
-nmap <buffer> <LocalLeader>p
-			\ <Plug>(traqvim-toggle-pin-operator)
-
 command! -buffer -nargs=0 TraqYankMessageLink
 			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])
 command! -buffer -nargs=0 TraqYankMessageMarkdown


### PR DESCRIPTION
Close #78 

ユーザーの設定と競合しないように、設定フレンドリーになりたいよね

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced customizable key mappings for various operations in the `traqvim` plugin.

- **Documentation**
  - Added a new section to the README for settings related to Vim key mappings.
  - Updated `doc/traqvim.jax` with new key mappings for message operations.

- **Refactor**
  - Renamed key mappings in `ftplugin/traqvim.vim` for consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->