### PR TITLE
サブコマンドを使って名前空間を侵さないようにした

### DIFF
--- a/autoload/command.vim
+++ b/autoload/command.vim
@@ -1,27 +1,29 @@
 
-let s:completions = #{
-			\ token: ['setup', 'delete'],
-			\ channel: ['open', 'home', 'reload', 'forward', 'back'],
-			\ activity: ['open', 'reload'],
-			\ message: ['open', 'send', 'delete', 'edit', 'editApply', 'yankLink', 'yankMarkdown'],
-			\ pin: ['create', 'remove'],
-			\}
-
 let s:subcommands = #{
 			\ token: #{
+			\   args: ['setup', 'delete'],
 			\   impl: function('command#token'),
+			\   comp: function('command#tokenComplete'),
 			\ },
 			\ channel: #{
+			\   args: ['open', 'home', 'reload', 'forward', 'back'],
 			\   impl: function('command#channel'),
+			\   comp: function('command#channelComplete'),
 			\ },
 			\ activity: #{
+			\   args: ['open', 'reload'],
 			\   impl: function('command#activity'),
+			\   comp: function('command#activityComplete'),
 			\ },
 			\ message: #{
+			\   args: ['open', 'send', 'delete', 'edit', 'editApply', 'yankLink', 'yankMarkdown'],
 			\   impl: function('command#message'),
+			\   comp: function('command#messageComplete'),
 			\ },
 			\ pin: #{
+			\   args: ['create', 'remove'],
 			\   impl: function('command#pin'),
+			\   comp: function('command#pinComplete'),
 			\ },
 			\}
 
@@ -31,6 +33,13 @@ function command#token(args) abort
 	elseif a:args[0] ==# 'delete'
 		call denops#request('traqvim', 'deleteOAuthToken', [])
 	endif
+endfunction
+
+function command#tokenComplete(arglead, cmdline) abort
+	if a:cmdline[strlen(a:cmdline)-1] ==# ' ' && len(split(a:cmdline)) >= 3
+		return []
+	endif
+	return s:subcommands.token.args->copy()->filter({_, v -> v =~? '^' . a:arglead})
 endfunction
 
 function command#channel(args) abort
@@ -48,12 +57,26 @@ function command#channel(args) abort
 	endif
 endfunction
 
+function command#channelComplete(arglead, cmdline) abort
+	if a:cmdline[strlen(a:cmdline)-1] ==# ' ' && len(split(a:cmdline)) >= 3
+		return []
+	endif
+	return s:subcommands.channel.args->copy()->filter({_, v -> v =~? '^' . a:arglead})
+endfunction
+
 function command#activity(args) abort
 	if a:args[0] ==# 'open'
 		call denops#request('traqvim', 'activity', [])
 	elseif a:args[0] ==# 'reload'
 		call denops#request('traqvim', 'reload', [bufnr(), bufname()])
 	endif
+endfunction
+
+function command#activityComplete(arglead, cmdline) abort
+	if a:cmdline[strlen(a:cmdline)-1] ==# ' ' && len(split(a:cmdline)) >= 3
+		return []
+	endif
+	return s:subcommands.activity.args->copy()->filter({_, v -> v =~? '^' . a:arglead})
 endfunction
 
 function command#message(args) abort
@@ -74,6 +97,13 @@ function command#message(args) abort
 	endif
 endfunction
 
+function command#messageComplete(arglead, cmdline) abort
+	if a:cmdline[strlen(a:cmdline)-1] ==# ' ' && len(split(a:cmdline)) >= 3
+		return []
+	endif
+	return s:subcommands.message.args->copy()->filter({_, v -> v =~? '^' . a:arglead})
+endfunction
+
 function command#pin(args) abort
 	if a:args[0] ==# 'create'
 		call denops#request('traqvim', 'createPin', [bufnr(), traqvim#get_message()])
@@ -82,22 +112,28 @@ function command#pin(args) abort
 	endif
 endfunction
 
-function command#complete(arglead, cmdline, cursorpos) abort
-	let cmdline = matchstr(a:cmdline, '^Traq\s\+\zs.*')
-	let cmds = split(cmdline)
-	let comp = s:completions->keys()
-	" TODO: 引数がネストしても適切に対応できるようにする
-	if ( a:cmdline[a:cursorpos - 1] == ' ' && len(cmds) == 1 )
-				\ || ( a:cmdline[a:cursorpos - 1] != ' ' && len(cmds) == 2 )
-		let comp = s:completions[cmds[0]]
-	elseif len(cmds) >= 2
-		let comp = []
+function command#pinComplete(arglead, cmdline) abort
+	if a:cmdline[strlen(a:cmdline)-1] ==# ' ' && len(split(a:cmdline)) >= 3
+		return []
 	endif
-	" argleadでフィルタリング
-	if a:arglead == ''
-		return comp
-	else
-		return filter(copy(comp), {_, v -> v =~? '^' . a:arglead})
+	return s:subcommands.pin.args->copy()->filter({_, v -> v =~? '^' . a:arglead})
+endfunction
+
+function command#complete(arglead, cmdline, cursorpos) abort
+	" subcommandを取得
+	let subcmd = matchstr(a:cmdline, '^Traq\s\+\zs\w\+')
+	let subcmdArgLead = matchstr(a:cmdline, '^Traq\s\+\w\+\s\+\zs\w\+')
+	" subcommandの引数を補完
+	if subcmd != ''
+				\ && has_key(s:subcommands, subcmd) == 1
+				\ && has_key(s:subcommands[subcmd], 'comp') == 1
+		return s:subcommands[subcmd].comp(a:arglead, a:cmdline)
+	endif
+	" subcommandを補完
+	let cmdline = matchstr(a:cmdline, '^Traq\s\+\w*$')
+	if cmdline != ''
+		let subcmdKeys = s:subcommands->keys()
+		return subcmdKeys->filter({_, v -> v =~? '^' . a:arglead})
 	endif
 endfunction
 

--- a/autoload/command.vim
+++ b/autoload/command.vim
@@ -1,0 +1,92 @@
+
+let s:completions = #{
+			\ token: ['setup', 'delete'],
+			\ channel: ['open', 'home', 'reload', 'forward', 'back'],
+			\ activity: ['open', 'reload'],
+			\ message: ['open', 'send', 'delete', 'edit', 'editApply', 'yankLink', 'yankMarkdown'],
+			\ pin: ['create', 'remove'],
+			\}
+
+function command#token(args) abort
+	if a:args[0] ==# 'setup'
+		call denops#request('traqvim', 'setupOAuth', [])
+	elseif a:args[0] ==# 'delete'
+		call denops#request('traqvim', 'deleteOAuthToken', [])
+	endif
+endfunction
+
+function command#channel(args) abort
+	if a:args[0] ==# 'open'
+		 " TODO:↓これtimeline APIの実装側が間違ってるのでいったんこのまま
+		call denops#request('traqvim', 'timeline', [a:args[1]])
+	elseif a:args[0] ==# 'home'
+		call denops#request('traqvim', 'home', [])
+	elseif a:args[0] ==# 'reload'
+		call denops#request('traqvim', 'reload', [bufnr(), bufname()])
+	elseif a:args[0] ==# 'forward'
+		call denops#request('traqvim', 'messageForwad', [bufnr(), bufname()])
+	elseif a:args[0] ==# 'back'
+		call denops#request('traqvim', 'messageBack', [bufnr(), bufname()])
+	endif
+endfunction
+
+function command#activity(args) abort
+	if a:args[0] ==# 'open'
+		call denops#request('traqvim', 'activity', [])
+	elseif a:args[0] ==# 'reload'
+		call denops#request('traqvim', 'reload', [bufnr(), bufname()])
+	endif
+endfunction
+
+function command#message(args) abort
+	if a:args[0] ==# 'open'
+		call denops#request('traqvim', 'messageOpen', [bufnr(), bufname()])
+	elseif a:args[0] ==# 'send'
+		call denops#request('traqvim', 'messageSend', [bufnr(), getline(1, '$')])
+	elseif a:args[0] ==# 'delete'
+		call denops#request('traqvim', 'messageDelete', [bufnr(), traqvim#get_message()])
+	elseif a:args[0] ==# 'edit'
+		call denops#request('traqvim', 'messageEditOpen', [bufnr(), traqvim#get_message()])
+	elseif a:args[0] ==# 'editApply'
+		call denops#request('traqvim', 'messageEdit', [getbufvar(bufname("%"), "editSourceBuffer"), getbufvar(bufname("%"), "message"), getline(1, '$')])
+	elseif a:args[0] ==# 'yankLink'
+		call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])
+	elseif a:args[0] ==# 'yankMarkdown'
+		call denops#request('traqvim', 'yankMessageMarkdown', [traqvim#get_message()])
+	endif
+endfunction
+
+function command#pin(args) abort
+	if a:args[0] ==# 'create'
+		call denops#request('traqvim', 'createPin', [bufnr(), traqvim#get_message()])
+	elseif a:args[0] ==# 'remove'
+		call denops#request('traqvim', 'removePin', [bufnr(), traqvim#get_message()])
+	endif
+endfunction
+
+function command#complete(arglead, cmdline, cursorpos) abort
+	let cmdline = matchstr(a:cmdline, '^Traq\s\+\zs.*')
+	let cmds = split(cmdline)
+	let comp = s:completions->keys()
+	" TODO: 引数がネストしても適切に対応できるようにする
+	if ( a:cmdline[a:cursorpos - 1] == ' ' && len(cmds) == 1 )
+				\ || ( a:cmdline[a:cursorpos - 1] != ' ' && len(cmds) == 2 )
+		let comp = s:completions[cmds[0]]
+	elseif len(cmds) >= 2
+		let comp = []
+	endif
+	" argleadでフィルタリング
+	if a:arglead == ''
+		return comp
+	else
+		return filter(copy(comp), {_, v -> v =~? '^' . a:arglead})
+	endif
+endfunction
+
+function command#call(rargs) abort
+	let args = split(a:rargs)
+	let cmd = args[0]
+	let FuncRef = function('command#' . cmd)
+	call FuncRef(args[1:])
+endfunction
+

--- a/autoload/command.vim
+++ b/autoload/command.vim
@@ -7,6 +7,24 @@ let s:completions = #{
 			\ pin: ['create', 'remove'],
 			\}
 
+let s:subcommands = #{
+			\ token: #{
+			\   impl: function('command#token'),
+			\ },
+			\ channel: #{
+			\   impl: function('command#channel'),
+			\ },
+			\ activity: #{
+			\   impl: function('command#activity'),
+			\ },
+			\ message: #{
+			\   impl: function('command#message'),
+			\ },
+			\ pin: #{
+			\   impl: function('command#pin'),
+			\ },
+			\}
+
 function command#token(args) abort
 	if a:args[0] ==# 'setup'
 		call denops#request('traqvim', 'setupOAuth', [])
@@ -85,8 +103,12 @@ endfunction
 
 function command#call(rargs) abort
 	let args = split(a:rargs)
-	let cmd = args[0]
-	let FuncRef = function('command#' . cmd)
-	call FuncRef(args[1:])
+	let subcommandKey = args[0]
+	let subcommand = s:subcommands->get(subcommandKey)
+	if type(subcommand) ==# type(0) && subcommand ==# 0
+		echomsg 'subcommand not found: ' . subcommandKey
+		return
+	endif
+	call subcommand.impl(args[1:])
 endfunction
 

--- a/ftplugin/traqvim.vim
+++ b/ftplugin/traqvim.vim
@@ -25,11 +25,6 @@ nnoremap <buffer><expr> <Plug>(traqvim-operator-pin-toggle)
 onoremap <buffer><silent> <Plug>(traqvim-motion-message)
 			\ :<C-u>call traqvim#message_motion()<CR>
 
-command! -buffer -nargs=0 TraqYankMessageLink
-			\ call denops#request('traqvim', 'yankMessageLink', [traqvim#get_message()])
-command! -buffer -nargs=0 TraqYankMessageMarkdown
-			\ call denops#request('traqvim', 'yankMessageMarkdown', [traqvim#get_message()])
-
 " filetypeがtraqvimの時かつ、ウィンドウのサイズが変更された時だけ実行
 
 augroup traqvim

--- a/plugin/traqvim.vim
+++ b/plugin/traqvim.vim
@@ -3,36 +3,11 @@
 " endif
 " let g:loaded_traq = 1
 "
-" :Traq setup でdenopsのsetupAPIを叩く
-command! TraqSetup call denops#request('traqvim', 'setupOAuth', [])
-" :Traq setup でdenopsのsetupAPIを叩く
-command! TraqDeleteToken call denops#request('traqvim', 'deleteOAuthToken', [])
-" homeChannelを開く
-command! TraqHome call denops#request('traqvim', 'home', [])
-" :Traq timeline でdenopsのtimelineAPIを叩く
-command! -nargs=1 TraqTimeline call denops#request('traqvim', 'timeline', [<q-args>])
-" activity
-command! TraqActivity call denops#request('traqvim', 'activity', [])
-" reload
-command! TraqReload call denops#request('traqvim', 'reload', [bufnr(), bufname()])
-" fetch forward
-command! TraqFetchForward call denops#request('traqvim', 'messageForward', [bufnr(), bufname()])
-" fetch backward
-command! TraqFetchBack call denops#request('traqvim', 'messageBack', [bufnr(), bufname()])
-" messageバッファの作成
-command! TraqMessageOpen call denops#request('traqvim', 'messageOpen', [bufnr(), bufname()])
-" messageの送信
-command! TraqMessageSend call denops#request('traqvim', 'messageSend', [bufnr(), getline(1, '$')])
-" messageの削除
-command! TraqMessageDelete call denops#request('traqvim', 'messageDelete', [bufnr(), traqvim#get_message()])
-" messageの編集
-command! TraqMessageEdit call denops#request('traqvim', 'messageEditOpen', [bufnr(), traqvim#get_message()])
-" messageの編集を適用
-command! TraqMessageEditApply call denops#request('traqvim', 'messageEdit', [getbufvar(bufname("%"), "editSourceBuffer"), getbufvar(bufname("%"), "message"), getline(1, '$')])
-" pinを作成
-command! TraqCreatePin call denops#request('traqvim', 'createPin', [bufnr(), traqvim#get_message()])
-" pinを削除
-command! TraqRemovePin call denops#request('traqvim', 'removePin', [bufnr(), traqvim#get_message()])
+
+command! -nargs=+
+			\ -complete=customlist,command#complete
+			\ Traq
+			\ call command#call(<q-args>)
 
 call helper#define_highlight()
 


### PR DESCRIPTION
https://github.com/nvim-neorocks/nvim-best-practices#speaking_head-user-commands

ここに書かれてるみたく
`:TraqMessageOpen` `:TraqMessageSend`みたいなのを

`:Traq message open` `:Traq message send`みたくできるようにした


ただ、なんちゃって実装＆既存の状態のディレクトリ分け等がもともと汚い
ってのもあって大幅修正する必要あり

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced command functionality for managing OAuth tokens, channels, activities, messages, and pins within the `traqvim` service.
  - Added command completion feature for easier command execution.

- **Refactor**
  - Unified multiple individual commands into a single versatile `Traq` command with flexible argument handling for various operations.

- **Removals**
  - Removed specific command declarations for yanking message links and markdown in `traqvim`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->