### PR TITLE
前後のmessageを更新しようとすると、型チェックで落ちるのを修正

### DIFF
--- a/denops/traqvim/model.ts
+++ b/denops/traqvim/model.ts
@@ -139,7 +139,17 @@ export const homeChannelId = async (): Promise<string> => {
 // userIdからユーザー情報を取得する
 export const getUser = async (userId: string): Promise<traq.User> => {
   const userRes = await api.api.getUser(userId);
-  const user = userRes.data;
+  const userDetail: traq.UserDetail = userRes.data;
+  // TODO: もっと良い変換方法ありそうなんで、見つけたらやっとく
+  const user: traq.User = {
+    id: userDetail.id,
+    name: userDetail.name,
+    displayName: userDetail.displayName,
+    iconFileId: userDetail.iconFileId,
+    bot: userDetail.bot,
+    state: userDetail.state,
+    updatedAt: userDetail.updatedAt,
+  };
   return user;
 };
 

--- a/denops/traqvim/model.ts
+++ b/denops/traqvim/model.ts
@@ -182,6 +182,11 @@ export const channelTimeline = async (
         )?.map((url: string) => {
           return url.split("/").slice(-1)[0];
         });
+        const ret: Message = {
+          ...message,
+          user: user,
+          createdAt: new Date(message.createdAt).toLocaleString("ja-JP"),
+        };
         // quotedMessageUUIDsが存在しなかった場合はundefinedを返す
         let quotedMessages: Message[] | undefined = undefined;
         if (quotedMessageUUIDs) {
@@ -202,12 +207,10 @@ export const channelTimeline = async (
             }),
           );
         }
-        return {
-          ...message,
-          user: user,
-          createdAt: new Date(message.createdAt).toLocaleString("ja-JP"),
-          quote: quotedMessages,
-        };
+        if (quotedMessages !== undefined) {
+          ret.quote = quotedMessages;
+        }
+        return ret;
       }),
   );
   return messagesConverted;


### PR DESCRIPTION
バッファ変数に保存してた情報にvim・denops側で齟齬が生じてたのが原因

denops→vimでundefined→0に解釈されるらしく、
vim→denopsと値が渡されたときにundefinedチェックできない

denops側でundefinedだったら、そもそもvim側に入れないように修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user data processing for improved clarity and type safety.
	- Improved message construction and handling in the channel timeline.
  
- **Bug Fixes**
	- Refined logic to ensure quoted messages are included only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->