### PR TITLE
メッセージをタイムラインに追加（挿入）する際にうまくいかないのを修正

### DIFF
--- a/autoload/traqvim/view.vim
+++ b/autoload/traqvim/view.vim
@@ -212,18 +212,18 @@ endfunction
 " これを利用してback, forwadの方のメッセージをhogehogeしたい
 function traqvim#view#draw_append_message(bufNum, message) abort
 	call setbufvar(a:bufNum, "&modifiable", 1)
-	let prevMessage = #{}
+	let prevMessageIndex = 0
 	" この関数を呼ばれる前に追加分が既にバッファ変数に登録されてる
 	let timeline = getbufvar(a:bufNum, "channelTimeline")
 	for message in timeline
 		if message.id == a:message.id
-			let prevMessage = message
+			let prevMessageIndex = message.position.index
 			break
 		endif
 	endfor
 	let start = 1
-	if !empty(prevMessage)
-		let start = prevMessage.position["end"] + 1
+	if prevMessageIndex
+		let start = timeline->get(prevMessageIndex-1)->get("position")->get("end") + 1
 	endif
 	let winnr = bufwinid(a:bufNum)
 	let width = winwidth(winnr)

--- a/autoload/traqvim/view.vim
+++ b/autoload/traqvim/view.vim
@@ -89,6 +89,7 @@ endfunction
 function traqvim#view#draw_timeline(bufNum) abort
 	call setbufvar(a:bufNum, "&modifiable", 1)
 	call sign_unplace("VtraQ", #{ buffer: a:bufNum })
+	" ここでindexの始まりが決定されてる
 	let index = 0
 	let start = 1
 	let winnr = bufwinid(a:bufNum)
@@ -97,6 +98,7 @@ function traqvim#view#draw_timeline(bufNum) abort
 		let mes = traqvim#view#make_message_body(message, width)
 		let end = start + len(mes.body) - 1
 		" 一度に全部描画するから、positionをここで設定する
+		" TODO: ここでバッファ変数を変更してるのを直す
 		let message.position = #{
 					\ index: index,
 					\ start: start,
@@ -117,6 +119,7 @@ function traqvim#view#draw_timeline(bufNum) abort
 	call setbufvar(a:bufNum, "&modifiable", 0)
 endfunction
 
+" TODO: 全部を描画しなおすんじゃなくて、フッターだけ再描画したいな
 function traqvim#view#redraw_recursive(layout) abort
 	if a:layout[0] ==# "leaf"
 		let bufNum = winbufnr(a:layout[1])
@@ -203,6 +206,10 @@ function traqvim#view#draw_delete_message(bufNum, message) abort
 	call setbufvar(a:bufNum, "&modifiable", 0)
 endfunction
 
+" indexの後のmessageを追加
+" positionのindexを0-indexか1-indexにするか悩むなぁ…
+" 現状は0-indexだから、いったんそれでいく
+" これを利用してback, forwadの方のメッセージをhogehogeしたい
 function traqvim#view#draw_append_message(bufNum, message) abort
 	call setbufvar(a:bufNum, "&modifiable", 1)
 	let prevMessage = #{}

--- a/autoload/traqvim/view.vim
+++ b/autoload/traqvim/view.vim
@@ -203,7 +203,7 @@ function traqvim#view#draw_delete_message(bufNum, message) abort
 	call setbufvar(a:bufNum, "&modifiable", 0)
 endfunction
 
-function traqvim#view#draw_insert_message(bufNum, message) abort
+function traqvim#view#draw_append_message(bufNum, message) abort
 	call setbufvar(a:bufNum, "&modifiable", 1)
 	let prevMessage = #{}
 	" この関数を呼ばれる前に追加分が既にバッファ変数に登録されてる

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -152,7 +152,7 @@ export const actionEditMessage = async (
     editedTimeline,
   );
   await denops.call(
-    "traqvim#view#draw_insert_message",
+    "traqvim#view#draw_append_message",
     bufNum,
     editedTimeline.find((m) => m.id === message.id),
   );

--- a/denops/traqvim/action.ts
+++ b/denops/traqvim/action.ts
@@ -134,6 +134,19 @@ export const actionEditMessage = async (
   // const timeline = await vars.buffers.get(denops, "channelTimeline");
   const timeline = await fn.getbufvar(denops, bufNum, "channelTimeline");
   assert(timeline, is.ArrayOf(isMessage));
+  // 削除したものをセット
+  await fn.setbufvar(
+    denops,
+    bufNum,
+    "channelTimeline",
+    timeline.filter((m) => m.id !== message.id),
+  );
+  await denops.call(
+    "traqvim#view#draw_delete_message",
+    bufNum,
+    message,
+  );
+  // 編集したものを追記
   const editedTimeline = timeline.map((m) => {
     if (m.id === message.id) {
       return {
@@ -144,7 +157,6 @@ export const actionEditMessage = async (
       return m;
     }
   });
-  // 編集したものをセット
   await fn.setbufvar(
     denops,
     bufNum,


### PR DESCRIPTION
メッセージ編集を適用する際に、元メッセージが削除されず、追記する形になっていた。
ただ、編集適用時に`:bdelete`でウィンドウが閉じ、それに伴いdraw_recursiveが走ってうまく表示されていてしまった。

そのため、メッセージを編集する際は
1. 元メッセージを削除＆position再計算
2. メッセージを挿入&position再計算

が走るようにした。
その後にdraw_recursiveが走り、無駄な計算が走るが、これはこのPRの責務じゃないので無視

また、draw関連のposition、index周りが既存のvim関数と似ておらず混乱するので、indexや描画インターフェースを改善するのも今後しておきたい

### Comments and Refactoring:

* [`autoload/traqvim/view.vim`](diffhunk://#diff-b2c5ceb4c33bcb8a380e999908d46508993618ed18d775bb8de1a0e00afeebcaR92): Added several TODO comments to indicate areas for future improvements and refactoring. [[1]](diffhunk://#diff-b2c5ceb4c33bcb8a380e999908d46508993618ed18d775bb8de1a0e00afeebcaR92) [[2]](diffhunk://#diff-b2c5ceb4c33bcb8a380e999908d46508993618ed18d775bb8de1a0e00afeebcaR101) [[3]](diffhunk://#diff-b2c5ceb4c33bcb8a380e999908d46508993618ed18d775bb8de1a0e00afeebcaR122) [[4]](diffhunk://#diff-b2c5ceb4c33bcb8a380e999908d46508993618ed18d775bb8de1a0e00afeebcaL206-R226)

### Function Modifications:

* [`autoload/traqvim/view.vim`](diffhunk://#diff-b2c5ceb4c33bcb8a380e999908d46508993618ed18d775bb8de1a0e00afeebcaL206-R226): Renamed the function `traqvim#view#draw_insert_message` to `traqvim#view#draw_append_message` and updated its logic to handle message positions differently.

### Timeline Management:

* [`denops/traqvim/action.ts`](diffhunk://#diff-7775eba3b26c656fa1c8415b2153ea0dbec48b8f651b00be02075e1e291499f6R137-R149): Updated the `actionEditMessage` function to delete and append messages in the `channelTimeline` buffer variable. [[1]](diffhunk://#diff-7775eba3b26c656fa1c8415b2153ea0dbec48b8f651b00be02075e1e291499f6R137-R149) [[2]](diffhunk://#diff-7775eba3b26c656fa1c8415b2153ea0dbec48b8f651b00be02075e1e291499f6L147-R167)