### PR TITLE
oauthのトークン取得時にvim側でメッセージを表示

### DIFF
--- a/denops/traqvim/oauth.ts
+++ b/denops/traqvim/oauth.ts
@@ -45,7 +45,7 @@ export class OAuth {
       try {
         const token = await this.oauth2client.code.getToken(url);
         api.setToken(token);
-        // ctx.response.body = "Success";
+        await helper.echo(this.denops, "oauth2 success!!\n token is setted");
         this.controller.abort();
       } catch (err) {
         console.error(err);


### PR DESCRIPTION

This pull request includes a small change to the `denops/traqvim/oauth.ts` file. The change updates the success message to be echoed when the OAuth token is set.

* [`denops/traqvim/oauth.ts`](diffhunk://#diff-ac823457acd1690d1c48d09dd8fabef29c8ebce03a9735d03bad14a8786d3c55L48-R48): Replaced a commented-out line with an echo message indicating OAuth success and that the token is set.